### PR TITLE
Add missing write barrier in IOU_initialize

### DIFF
--- a/ext/iou/ring.c
+++ b/ext/iou/ring.c
@@ -81,7 +81,7 @@ VALUE IOURing_initialize(VALUE self) {
   iour->unsubmitted_sqes = 0;
   iour->br_counter = 0;
 
-  iour->pending_ops = rb_hash_new();
+  RB_OBJ_WRITE(self, &iour->pending_ops, rb_hash_new());
 
   unsigned prepared_limit = 1024;
   int flags = 0;


### PR DESCRIPTION
Since it's the initialize method, it's extremely unlikely that `self` would have reached the old generation, hence almost impossible to run into this bug short of using `GC.stress`.

But still, that write barrier is technically needed.